### PR TITLE
Fix mech arms issues

### DIFF
--- a/Starbound Patch Project/vehicles/modularmech/armscripts/beamweaponarm.lua
+++ b/Starbound Patch Project/vehicles/modularmech/armscripts/beamweaponarm.lua
@@ -1,0 +1,149 @@
+require "/vehicles/modularmech/armscripts/base.lua"
+
+BeamArm = MechArm:extend()
+
+function BeamArm:init()
+  self.state = FSM:new()
+
+  if self.chain ~= nil then
+    self.chain.sourcePart = self.armName
+    self.chain.endPart = self.armName
+  end
+  self.renderChain = false
+end
+
+function BeamArm:update(dt)
+  if self.state.state then
+    self.state:update()
+  end
+
+  if not self.state.state then
+    if self.isFiring then
+      self.state:set(self.windupState, self)
+    end
+  end
+
+  if self.state.state then
+    self.bobLocked = true
+  else
+    animator.setAnimationState(self.armName, "idle")
+    self.bobLocked = false
+  end
+end
+
+function BeamArm:windupState()
+  local stateTimer = self.windupTime
+
+  animator.setAnimationState(self.armName, "windup")
+  animator.playSound(self.armName .. "Windup")
+
+  while stateTimer > 0 do
+    animator.rotateTransformationGroup(self.armName, self.aimAngle, self.shoulderOffset)
+
+    local dt = script.updateDt()
+    stateTimer = stateTimer - dt
+    coroutine.yield()
+  end
+
+  if self.isFiring and self:rayCheck(self.firePosition) then
+    self.state:set(self.fireState, self)
+  else
+    self.state:set(self.winddownState, self)
+    animator.playSound(self.armName .. "WinddownNoFire")
+  end
+end
+
+function BeamArm:fireState()
+  local stateTimer = self.fireTime
+
+  animator.rotateTransformationGroup(self.armName, self.aimAngle, self.shoulderOffset)
+
+  local endPoint, beamCollision, beamLength = self:updateBeam()
+
+  animator.playSound(self.armName .. "Fire")
+  animator.setParticleEmitterBurstCount(self.armName .. "Beam", math.ceil(self.beamParticleDensity * beamLength))
+  animator.burstParticleEmitter(self.armName .. "Beam")
+  if self.scriptedBeam then
+    self.renderChain = true
+  else
+    animator.setAnimationState(self.armName .. "Beam", "fire", true)
+  end
+  
+  vehicle.setDamageSourceEnabled(self.armName .. "Beam", true)
+
+  self.aimLocked = self.lockAim
+
+  if beamCollision and self.beamTileDamage > 0 then
+    local maximumEndPoint = vec2.add(self.firePosition, vec2.mul(self.aimVector, self.beamLength))
+    local damagePositions = world.collisionBlocksAlongLine(self.firePosition, maximumEndPoint, nil, self.beamTileDamageDepth)
+    local driver = vehicle.entityLoungingIn("seat")
+    world.damageTiles(damagePositions, "foreground", self.firePosition, "beamish", self.beamTileDamage, 99, driver)
+    world.damageTiles(damagePositions, "background", self.firePosition, "beamish", self.beamTileDamage, 99, driver)
+  end
+
+  coroutine.yield()
+
+  while stateTimer > 0 and (self.holdFire or self.isFiring) and self:rayCheck(self.firePosition) do
+    animator.rotateTransformationGroup(self.armName, self.aimAngle, self.shoulderOffset)
+
+    self:updateBeam()
+
+    local dt = script.updateDt()
+    stateTimer = stateTimer - dt
+    coroutine.yield()
+  end
+
+  self.aimLocked = false
+  
+  if self.scriptedBeam then
+    self.renderChain = false
+  end
+
+  vehicle.setDamageSourceEnabled(self.armName .. "Beam", false)
+
+  if self.isFiring and self.repeatFire and self:rayCheck(self.firePosition) then
+    self.state:set(self.fireState, self)
+  else
+    self.state:set(self.winddownState, self)
+  end
+end
+
+function BeamArm:winddownState()
+  local stateTimer = self.winddownTime or 0
+
+  animator.setAnimationState(self.armName, "winddown")
+  animator.playSound(self.armName .. "Winddown")
+  
+  if self.scriptedBeam then
+    vehicle.setAnimationParameter("chains", {})
+  end
+
+  while stateTimer > 0 do
+    animator.rotateTransformationGroup(self.armName, self.aimAngle, self.shoulderOffset)
+
+    local dt = script.updateDt()
+    stateTimer = stateTimer - dt
+    coroutine.yield()
+  end
+
+  self.state:set()
+end
+
+function BeamArm:updateBeam()
+  local endPoint = vec2.add(self.firePosition, vec2.mul(self.aimVector, self.beamLength))
+  local beamCollision = world.lineCollision(self.firePosition, endPoint)
+  if beamCollision then
+    endPoint = beamCollision
+  end
+  local beamLength = world.magnitude(self.firePosition, endPoint)
+
+  if not self.scriptedBeam then
+    animator.resetTransformationGroup(self.armName .. "Beam")
+    animator.scaleTransformationGroup(self.armName .. "Beam", {beamLength, 1}, {self.beamSourceOffset[1], self.beamSourceOffset[2] - self.beamHeight / 2})
+  end
+
+  local particleRegion = {self.beamSourceOffset[1], self.beamSourceOffset[2], self.beamSourceOffset[1] + beamLength, self.beamSourceOffset[2]}
+  animator.setParticleEmitterOffsetRegion(self.armName .. "Beam", particleRegion)
+
+  return endPoint, beamCollision, beamLength
+end

--- a/Starbound Patch Project/vehicles/modularmech/armscripts/dasharm.lua
+++ b/Starbound Patch Project/vehicles/modularmech/armscripts/dasharm.lua
@@ -1,0 +1,109 @@
+require "/vehicles/modularmech/armscripts/base.lua"
+
+DashArm = MechArm:extend()
+
+function DashArm:init()
+
+  self.state = FSM:new()
+end
+
+function DashArm:update(dt)
+  if self.state.state then
+    self.state:update()
+  end
+
+  if not self.state.state then
+    if self.fireTriggered then
+      self.state:set(self.windupState, self)
+    end
+  end
+
+  if self.state.state then
+    self.bobLocked = true
+  else
+    animator.setAnimationState(self.armName, "idle")
+    self.bobLocked = false
+  end
+end
+
+function DashArm:windupState()
+  animator.setAnimationState(self.armName, "windup")
+
+  local stateTimer = self.windupTime
+
+  -- The vanilla logic will work in zero-G or in low gravity. However,
+  -- it will not work in full gravity environments, because there the
+  -- gravity causes a continuous minimum of ~-1.18 on the y-axis of the
+  -- velocity vector, even when the mech is stationary.
+  local gravity = world.gravity(mcontroller.position())
+  local maxInitialVelocity = 1.0
+  if gravity > 0 and gravity <= 40 then
+    maxInitialVelocity = 1.6
+  elseif gravity > 40 then
+    maxInitialVelocity = 2.2
+  end
+
+  while vec2.mag(mcontroller.velocity()) > maxInitialVelocity or stateTimer > 0 do
+    animator.rotateTransformationGroup(self.armName, self.aimAngle + self.windupAngle, self.shoulderOffset)
+    stateTimer = stateTimer - script.updateDt()
+    mcontroller.approachVelocity({0.0, 0.0}, self.stopForce)
+    coroutine.yield()
+  end
+
+  self.state:set(self.fireState, self, self.windupAngle, self.fireAngle)
+end
+
+function DashArm:fireState(fromAngle, toAngle)
+  animator.playSound(self.armName .. "Fire")
+
+  local stateTimer = self.fireTime
+  local projectileSpawnTime = stateTimer - self.swingTime
+  local fireWasTriggered = false
+  local dashDir = self.aimVector
+  local startVelocity = mcontroller.velocity()
+
+  animator.setParticleEmitterActive(self.armName.."Dash", true)
+  animator.resetTransformationGroup("dash")
+  animator.rotateTransformationGroup("dash", self.aimAngle)
+  while stateTimer > 0 do
+    fireWasTriggered = fireWasTriggered or self.fireTriggered
+    
+    vehicle.setDamageTeam({type = "ghostly"})
+    vehicle.setDamageSourceEnabled("bumperGround", false)
+
+    mcontroller.setVelocity(vec2.mul(dashDir, self.dashSpeed))
+    animator.setGlobalTag("directives", self.dashDirectives)
+
+    local swingRatio = math.min(1, (self.fireTime - stateTimer) / self.swingTime)
+    local currentAngle = util.lerp(swingRatio, fromAngle, toAngle)
+    animator.rotateTransformationGroup(self.armName, self.aimAngle + currentAngle, self.shoulderOffset)
+
+    local dt = script.updateDt()
+    if stateTimer > projectileSpawnTime and (stateTimer - projectileSpawnTime) < dt then
+      self:fire()
+    end
+
+    stateTimer = stateTimer - dt
+    coroutine.yield()
+  end
+  
+  animator.setParticleEmitterActive(self.armName.."Dash", false)
+  animator.setGlobalTag("directives", "")
+  
+  mcontroller.setVelocity({0, 0})
+  
+  self.state:set(self.cooldownState, self)
+end
+
+function DashArm:cooldownState()
+  animator.setAnimationState(self.armName, "winddown")
+
+  local stateTimer = self.cooldownTime
+  while stateTimer > 0 do
+    animator.rotateTransformationGroup(self.armName, self.cooldownAngle, self.shoulderOffset)
+    stateTimer = stateTimer - script.updateDt()
+    coroutine.yield()
+  end
+
+  self.state:set()
+end

--- a/Starbound Patch Project/vehicles/modularmech/mechparts_arm.config.patch
+++ b/Starbound Patch Project/vehicles/modularmech/mechparts_arm.config.patch
@@ -1,0 +1,10 @@
+[
+  { "op" : "replace",
+    "path" : "/beamsniper/partParameters/script",
+    "value" : "/vehicles/modularmech/armscripts/beamweaponarm.lua"
+  },
+  { "op" : "replace",
+    "path" : "/neolaser/partParameters/script",
+    "value" : "/vehicles/modularmech/armscripts/beamweaponarm.lua"
+  }
+]


### PR DESCRIPTION
* In vanilla, the Beam Sniper and Neo Laser mech arms can fire through a
  solid wall, if the mech is pushed up against the wall such that the
  muzzle of the weapon passes through the wall. This is due to a lack of
  tile collision checks in beamarm.lua. I forked it and added the
  collision checks because beamarm.lua is also used by the Beam Drill
  mech arm, and that arm doesn't behave well as a drill when collision
  checks are active.
* In vanilla, the Solus Katana mech arm does not work properly in a full
  gravity environment. Its windup phase slows the mech to below a
  specific threshold, but due to how gravity and velocity are modeled in
  Starbound, this does not work properly in a full gravity environment,
  and the arm gets stuck indefinitely in windup. This edit compensates
  for gravity by altering the velocity threshold in gravity
  environments. This is more of a kludge than an elegant solution, but I
  think it's the best that can be done without a major rewrite.