### PR TITLE
Snwomen dropping wrong wood

### DIFF
--- a/Starbound Patch Project/objects/biome/snow/fancysnowman/fancysnowman.object.patch
+++ b/Starbound Patch Project/objects/biome/snow/fancysnowman/fancysnowman.object.patch
@@ -1,0 +1,11 @@
+[
+    [{
+        "op": "test",
+        "path": "/smashDropOptions/0/4/0",
+        "value": "fullwood1"
+    },{
+        "op": "replace",
+        "path": "/smashDropOptions/0/4/0",
+        "value": "logblock"
+    }]
+]

--- a/Starbound Patch Project/objects/biome/snow/snowman/snowman.object.patch
+++ b/Starbound Patch Project/objects/biome/snow/snowman/snowman.object.patch
@@ -1,0 +1,11 @@
+[
+    [{
+        "op": "test",
+        "path": "/smashDropOptions/0/4/0",
+        "value": "fullwood1"
+    },{
+        "op": "replace",
+        "path": "/smashDropOptions/0/4/0",
+        "value": "logblock"
+    }]
+]


### PR DESCRIPTION
Snowmen use to be crafted with Unrefined Wood. When Unrefined Wood's role was replaced with Log Blocks, they changed the recipe, but not the type of wood obtained by smashing a snowman.

Silbr fixed it :3