### PR TITLE
Fix Quagmutt Action Figure drop from Bow;

### DIFF
--- a/Starbound Patch Project/treasure/hunting.treasurepools.patch
+++ b/Starbound Patch Project/treasure/hunting.treasurepools.patch
@@ -1,0 +1,7 @@
+[
+    {
+        "op": "replace",
+        "path": "/quagmuttHunting/0/1/pool/2/item",
+        "value": "quagmuttaf"
+    }
+]


### PR DESCRIPTION
Quagmutt treasure pool was fixed so Action Figure can also be dropped from a bow-kill (there is a typo in vanilla assets: "guagmutt");