### PR TITLE
Peacekeepervendingmachine: collision + shortdesc fix

### DIFF
--- a/Starbound Patch Project/objects/peacekeeper/peacekeepervendingmachine/peacekeepervendingmachine.object.patch
+++ b/Starbound Patch Project/objects/peacekeeper/peacekeepervendingmachine/peacekeepervendingmachine.object.patch
@@ -1,0 +1,37 @@
+[
+  //Make shortdesscription fit tooltip
+  [
+    {
+      "op": "test",
+      "path": "/shortdescription",
+      "value": "Peacekeeper Vending Machine"
+    }, {
+      "op": "replace",
+      "path": "/shortdescription",
+      "value": "Donut Vending Machine"
+    }
+  ],
+
+  //Remove bugged manually-defined "top of vending machine" collision because its platform collision handles this
+  //Plus, the manually-defined ones are missing a spot
+  [
+    {
+      "op": "test",
+      "path": "/orientations/0/collisionSpaces",
+      "value": [[-1, 3], [0, 3]]
+    }, {
+      "op": "remove",
+      "path": "/orientations/0/collisionSpaces"
+    }
+  ],
+  [
+    {
+      "op": "test",
+      "path": "/orientations/1/collisionSpaces",
+      "value": [[-1, 3], [0, 3]]
+    }, {
+      "op": "remove",
+      "path": "/orientations/1/collisionSpaces"
+    }
+  ]
+]


### PR DESCRIPTION
Fix shortdescription from flowing out of tooltip
Fix collision (it has a missing platform space on its surface)