### PR TITLE
Make frontiervault actually stackable

### DIFF
--- a/Starbound Patch Project/objects/novakid/frontiervault/frontiervault.object.patch
+++ b/Starbound Patch Project/objects/novakid/frontiervault/frontiervault.object.patch
@@ -1,0 +1,1 @@
+[{"op":"remove","path":"/orientations/1/collisionSpaces"},{"op":"remove","path":"/orientations/0/collisionSpaces"}]


### PR DESCRIPTION
The vanilla frontiervault is stackable but the last tile doesn't allow any objects to be placed on top so it can't actually stack with itself, this should fix it

![image](https://github.com/user-attachments/assets/e913bc1c-9e2f-4e09-90ac-52f55a729425)

The patch is a bit weird as it just removes the set collision values but everything seems to work as it should?