### PR TITLE
give lightbow legendary rarity

### DIFF
--- a/Starbound Patch Project/items/active/weapons/bow/lightbow/lightbow.activeitem.patch
+++ b/Starbound Patch Project/items/active/weapons/bow/lightbow/lightbow.activeitem.patch
@@ -1,0 +1,7 @@
+[
+    {
+        "op": "replace",
+        "path": "/rarity",
+        "value": "Legendary"
+    }
+]


### PR DESCRIPTION
Only unique random drop weapon with inexplicably different rarity in vanilla

![image](https://github.com/user-attachments/assets/c2df4820-4949-4396-b8ac-545e1b0ac55b)
