### PR TITLE
Copy amored cultist armor patches to regular cultist armor

### DIFF
--- a/Starbound Patch Project/items/armors/other/cultist/cultist.chest.patch
+++ b/Starbound Patch Project/items/armors/other/cultist/cultist.chest.patch
@@ -1,0 +1,26 @@
+[
+  [
+    {
+      "op" : "test",
+      "path" : "/rarity",
+      "value" : "Common"
+    },
+    {
+      "op" : "replace",
+      "path" : "/rarity",
+      "value" : "Uncommon"
+    }
+  ],
+  [
+    {
+      "op" : "test",
+      "path" : "/price",
+      "value" : 0
+    },
+    {
+      "op" : "replace",
+      "path" : "/price",
+      "value" : 250
+    }
+  ]
+]

--- a/Starbound Patch Project/items/armors/other/cultist/cultist.head.patch
+++ b/Starbound Patch Project/items/armors/other/cultist/cultist.head.patch
@@ -1,0 +1,26 @@
+[
+  [
+    {
+      "op" : "test",
+      "path" : "/rarity",
+      "value" : "Common"
+    },
+    {
+      "op" : "replace",
+      "path" : "/rarity",
+      "value" : "Uncommon"
+    }
+  ],
+  [
+    {
+      "op" : "test",
+      "path" : "/price",
+      "value" : 0
+    },
+    {
+      "op" : "replace",
+      "path" : "/price",
+      "value" : 250
+    }
+  ]
+]

--- a/Starbound Patch Project/items/armors/other/cultist/cultist.legs.patch
+++ b/Starbound Patch Project/items/armors/other/cultist/cultist.legs.patch
@@ -1,0 +1,26 @@
+[
+  [
+    {
+      "op" : "test",
+      "path" : "/rarity",
+      "value" : "Common"
+    },
+    {
+      "op" : "replace",
+      "path" : "/rarity",
+      "value" : "Uncommon"
+    }
+  ],
+  [
+    {
+      "op" : "test",
+      "path" : "/price",
+      "value" : 0
+    },
+    {
+      "op" : "replace",
+      "path" : "/price",
+      "value" : 250
+    }
+  ]
+]


### PR DESCRIPTION
Changing rarity to uncommon and increasing price to 250 pixels

this makes it match with the armored cultist set / other mission sets, the treasurepool is under the missions folder and with a 1% drop rate it's only really feasable to complete this set by grinding the glitch artifact/cultist mission, so i think it's fair to treat it as a mission set