### PR TITLE
adjust protectoratesmokegen racial descriptions

### DIFF
--- a/Starbound Patch Project/objects/protectorate/objects/protectoratesmokegen/protectoratesmokegen.object.patch
+++ b/Starbound Patch Project/objects/protectorate/objects/protectoratesmokegen/protectoratesmokegen.object.patch
@@ -1,0 +1,37 @@
+[
+    {
+        "op": "replace",
+        "path": "/novakidDescription",
+        "value": "Smoke."
+    },
+    {
+        "op": "replace",
+        "path": "/hylotlDescription",
+        "value": "Smoke."
+    },
+    {
+        "op": "replace",
+        "path": "/humanDescription",
+        "value": "Smoke."
+    },
+    {
+        "op": "replace",
+        "path": "/glitchDescription",
+        "value": "Observant. Smoke."
+    },
+    {
+        "op": "replace",
+        "path": "/floranDescription",
+        "value": "Sssmoke."
+    },
+    {
+        "op": "replace",
+        "path": "/avianDescription",
+        "value": "Smoke."
+    },
+    {
+        "op": "replace",
+        "path": "/apexDescription",
+        "value": "Smoke."
+    }
+]


### PR DESCRIPTION
During the intro mission there's scannable smoke which just has the description "Smoke" for all races.

This PR makes it similar to most wired objects where glitch and florans get unique descriptions, other races' descriptions had punctuation added.

![image](https://github.com/user-attachments/assets/d01f9b0c-9e2f-4ca2-9ba4-d68d4435a3f8)
