### PR TITLE
Changed move ops to copy ops

### DIFF
--- a/Starbound Patch Project/interface/scripted/techupgrade/techupgradegui.config.patch
+++ b/Starbound Patch Project/interface/scripted/techupgrade/techupgradegui.config.patch
@@ -10,7 +10,7 @@
     "inverse" : true
   },
   {
-    "op" : "move",
+    "op" : "copy",
     "from" : "/gui/imgSelected/zLevel",
     "path" : "/gui/imgSelected/zlevel"
   }

--- a/Starbound Patch Project/items/active/unsorted/wateringcan/wateringcan.activeitem.patch
+++ b/Starbound Patch Project/items/active/unsorted/wateringcan/wateringcan.activeitem.patch
@@ -5,7 +5,7 @@
       "op" : "test",
       "path" : "/maxStack",
       "value" : 175
-    }
+    },
     {
       "op" : "replace",
       "path" : "/maxStack",

--- a/Starbound Patch Project/npcs/dungeon/aviannativevillage/stargazer.npctype.patch
+++ b/Starbound Patch Project/npcs/dungeon/aviannativevillage/stargazer.npctype.patch
@@ -22,7 +22,7 @@
       "inverse" : true
     },
     {
-      "op" : "move",
+      "op" : "copy",
       "from": "/behaviorConfig",
       "path": "/scriptConfig/behaviorConfig"
     }
@@ -39,7 +39,7 @@
       "inverse" : true
     },
     {
-      "op" : "move",
+      "op" : "copy",
       "from": "/dialog",
       "path": "/scriptConfig/dialog"
     }

--- a/Starbound Patch Project/npcs/outpost/outposthylotlcurator.npctype.patch
+++ b/Starbound Patch Project/npcs/outpost/outposthylotlcurator.npctype.patch
@@ -10,7 +10,7 @@
 		"inverse" : true
 	},
 	{
-		"op" : "move",
+		"op" : "copy",
 		"from" : "/scriptConfig/dialog/converse/Hylotl",
 		"path" : "/scriptConfig/dialog/converse/hylotl"
 	}

--- a/Starbound Patch Project/npcs/tenants/aviantomb.npctype.patch
+++ b/Starbound Patch Project/npcs/tenants/aviantomb.npctype.patch
@@ -10,7 +10,7 @@
     "inverse" : true
   },
   {
-    "op" : "move",
+    "op" : "copy",
     "from" : "/dialog",
     "path" : "/scriptConfig/dialog"
   }

--- a/Starbound Patch Project/objects/arttrophies/sandstonestatueglitch/sandstonestatueglitch.object.patch
+++ b/Starbound Patch Project/objects/arttrophies/sandstonestatueglitch/sandstonestatueglitch.object.patch
@@ -11,7 +11,7 @@
       "inverse" : true
     },
     {
-      "op" : "move",
+      "op" : "copy",
       "from": "/genericDescription",
       "path": "/avianDescription"
     }


### PR DESCRIPTION
This fixes compatibility issues with older and/or sloppily-made mods that try to patch things that are in the wrong place to begin with.