### PR TITLE
Disable hostile hp bar on Pinfriend by default

### DIFF
--- a/Starbound Patch Project/monsters/dungeon/pinfriend/pinfriend.monstertype.patch
+++ b/Starbound Patch Project/monsters/dungeon/pinfriend/pinfriend.monstertype.patch
@@ -22,5 +22,17 @@
       "path" : "/description",
       "value" : "It is said that dogs are a man's best friend, but this one doesn't seem to discriminate."
     }
+  ],
+  [
+    {
+      "op" : "test",
+      "path" : "/baseParameters/damageTeamType",
+      "inverse" : true
+    },
+    {
+      "op" : "add",
+      "path" : "/baseParameters/damageTeamType",
+      "value" : "friendly"
+    }
   ]
 ]


### PR DESCRIPTION
Updates Pinfriend's damageTeamType to "friendly" to get rid of the hostile hp bar that shows on Pinfriend at the Outpost