### PR TITLE
The Barrel Fire is not a crafting station.

### DIFF
--- a/Starbound Patch Project/objects/human/prisonbarrelfire/prisonbarrelfire.object.patch
+++ b/Starbound Patch Project/objects/human/prisonbarrelfire/prisonbarrelfire.object.patch
@@ -1,0 +1,14 @@
+[
+  [
+    {
+      "op" : "test",
+      "path" : "/category",
+      "value" : "crafting"
+    },
+    {
+      "op" : "replace",
+      "path" : "/category",
+      "value" : "decorative"
+    }
+  ]
+]


### PR DESCRIPTION
Changed the 'category' of the Barrel Fire from "crafting" to "decorative".