### PR TITLE
Update mechblueprint6.activeitem.patch

### DIFF
--- a/Starbound Patch Project/items/active/randomblueprint/mechblueprint6.activeitem.patch
+++ b/Starbound Patch Project/items/active/randomblueprint/mechblueprint6.activeitem.patch
@@ -1,12 +1,39 @@
 [
-  {
-    "op" : "test",
-    "path" : "/category",
-    "value" : "Blueprint"
-  },
-  {
-    "op" : "replace",
-    "path" : "/category",
-    "value" : "blueprint"
-  }
+  [
+    {
+      "op": "test",
+      "path": "/category",
+      "value": "Blueprint"
+    }, {
+      "op": "replace",
+      "path": "/category",
+      "value": "blueprint"
+    }
+  ],
+
+  //Change tooltip to account for shortdescription's length
+  [
+    {
+      "op": "test",
+      "path": "/tooltipKind",
+      "value": "base"
+    }, {
+      "op": "replace",
+      "path": "/tooltipKind",
+      "value": "codex"
+    }
+  ],
+
+  //Other mech blueprints don't inherit descriptors from past tiers. Drop 'high-tech' for consistency
+  [
+    {
+      "op": "test",
+      "path": "/description",
+      "value": "A blueprint for an experimental high-tech mech part."
+    }, {
+      "op": "replace",
+      "path": "/description",
+      "value": "A blueprint for an experimental mech part."
+    }
+  ]
 ]


### PR DESCRIPTION
* Change tooltip to a wider one since shortdesc is too long
* Change 'experimental high-tech' to 'experimental' since the high-tech one doesn't say 'advanced high-tech' just because the tier before it was 'advanced'