### PR TITLE
volatilepowder: new price

### DIFF
--- a/Starbound Patch Project/items/generic/crafting/volatilepowder.item.patch
+++ b/Starbound Patch Project/items/generic/crafting/volatilepowder.item.patch
@@ -7,6 +7,6 @@
   {
     "op" : "replace",
     "path" : "/price",
-    "value" : 40
+    "value" : 20
   }
 ]


### PR DESCRIPTION
Price goes from 40 to 20, making the price equal to the two core fragments required to make it, like how the copper bar price is the same as the two copper ores used to make it